### PR TITLE
Shown remaining break seconds in "cup"

### DIFF
--- a/Take5/formMain.cs
+++ b/Take5/formMain.cs
@@ -495,6 +495,7 @@ namespace Take5
                         this.Top = scrY - this.Height - 24;
 
                     //TakeBreak.Text = randomButtonText();
+                    TakeBreak.TextAlign = ContentAlignment.BottomCenter;
                     TakeBreak.Text = "You need to take a break";
 
                     if (playBeep)
@@ -549,7 +550,8 @@ namespace Take5
 
         private void timerBreak_Tick(object sender, EventArgs e)
         {
-            TakeBreak.Text = breakSecsRemain.ToString() + " seconds left";
+            TakeBreak.TextAlign = ContentAlignment.MiddleCenter;
+            TakeBreak.Text = breakSecsRemain.ToString(); // display seconds left in the middle of the cup
             if (playTicks)
                 PlaySound(Application.StartupPath + "\\tick.wav", 0, SND_ASYNC);
 


### PR DESCRIPTION
It can sometimes be hard to read the countdown timer whilst in a break
due to the colour clash.
I have moves the seconds countdown display to the middle of the white
cup. This is more easier to see. They less eye strain the better :-)
I have also removed the text “seconds left” as I thought this was no
longer necessary.
