### PR TITLE
Notify user with “balloon” message when 5% of time remaining before b…

### DIFF
--- a/Take5/formMain.cs
+++ b/Take5/formMain.cs
@@ -65,7 +65,7 @@ namespace Take5
         public bool firstRun;
         private bool movedAround;
         private bool pauseWhenFullscreen, resetWhenIdle, playBeep, playTicks;
-
+        private bool notifiedAboutBreakComing;
 
         private bool userInFullscreen()
         {
@@ -147,6 +147,7 @@ namespace Take5
             {
                 minsRemain = countMins;
                 secsRemain = 0;
+                notifiedAboutBreakComing = false;
             }
         }
 
@@ -475,7 +476,16 @@ namespace Take5
                 secsRemain = 59;
 
                 if (minsRemain > 0)
+                {
+                    // check if time left has become less than 5% of total time.
+                    // if so popup up a balloon bubble to notify a break is coming soon.
+                    if (!notifiedAboutBreakComing && (double)minsRemain / countMins <= 0.05) // 0.05 is the 5%
+                    {
+                        trayIcon.ShowBalloonTip(5000, "Take5", "Break coming in " + minsRemain.ToString() + " min(s)...", ToolTipIcon.Info);
+                        notifiedAboutBreakComing = true;
+                    }
                     minsRemain--;
+                }                    
                 else
                 {
                     scrX = GetSystemMetrics(SM_CXSCREEN);
@@ -503,6 +513,8 @@ namespace Take5
                     effect = Fade.In;
                     timerFadeEffect.Enabled = true;
                     timerCountdown.Enabled = false;
+
+                    notifiedAboutBreakComing = false; // reset toggle
                 }
 
                 //save countdown as percentage in text file


### PR DESCRIPTION
…reak is reached.

I have found this feature very useful in other “break” software as it
allows the user to prepare themselves for a upcoming break. As the event
is no longer a surprise they are more likely to take the break instead
of just ignoring the software.

I have build this in as a none configurable feature but it could be
added behind a on/off toggle config if you think some users would never
want this(?).
