### PR TITLE
Single click on icon for options - take 2

### DIFF
--- a/Take5/formMain.Designer.cs
+++ b/Take5/formMain.Designer.cs
@@ -49,7 +49,7 @@
             this.trayIcon.Icon = ((System.Drawing.Icon)(resources.GetObject("trayIcon.Icon")));
             this.trayIcon.Text = "Take5";
             this.trayIcon.Visible = true;
-            this.trayIcon.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.trayIcon_MouseDoubleClick);
+            this.trayIcon.MouseClick += new System.Windows.Forms.MouseEventHandler(this.trayIcon_MouseClick);
             // 
             // timerBreak
             // 

--- a/Take5/formMain.cs
+++ b/Take5/formMain.cs
@@ -324,7 +324,7 @@ namespace Take5
                     }
                 }
 
-                trayIcon.ShowBalloonTip(10000, "Take5", "First time running Take5? Double click this icon to view options.", ToolTipIcon.Info);
+                trayIcon.ShowBalloonTip(10000, "Take5", "First time running Take5? Click this icon to view options.", ToolTipIcon.Info);
             }
 
             firstRun = false; // set this now and save so that the users does not potentially get above msgbox on mutiple runs
@@ -408,7 +408,7 @@ namespace Take5
             picSteam.Visible = false;
         }
 
-        private void trayIcon_MouseDoubleClick(object sender, MouseEventArgs e)
+        private void trayIcon_MouseClick(object sender, MouseEventArgs e)
         {
             showOptions();
         }


### PR DESCRIPTION
For a while using this app I kept right clicking on the icon and then
getting to the options menu. I did not see the initial notification
advising that double click would do this.
I only say you could double click this when I saw the line of code which
does the balloon.
Most other apps' tray icons respond to single click.
Therefore I have made this single click as other users might make the
same mistake I did.
Re-submit of this commit.
